### PR TITLE
feat: low-level keyboard hook for hold/toggle hotkeys

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -65,7 +65,7 @@ function initHotkeys(): void {
   _hotkeyManager = new HotkeyManager();
   const swarm = getSwarm();
 
-  _hotkeyManager.onAction(async (action, args) => {
+  _hotkeyManager.onAction(async (action, _eventType, args) => {
     try {
       switch (action) {
         case 'toggle-visibility':

--- a/src/hotkeys/config.ts
+++ b/src/hotkeys/config.ts
@@ -5,7 +5,8 @@ import { parse as parseYaml } from 'yaml';
 import { KeybindingsConfigSchema, type KeybindingsConfig, type Keybinding } from './types.js';
 
 const DEFAULT_BINDINGS: Keybinding[] = [
-  { key: 'ctrl+alt+space', action: 'voice-activate' },
+  { key: 'ctrl+tab', action: 'voice-ptt', mode: 'hold' },
+  { key: 'ctrl+tab+`', action: 'voice-toggle' },
   { key: 'ctrl+shift+s', action: 'toggle-visibility' },
   { key: 'ctrl+shift+1', action: 'focus-worm', args: { number: 1 } },
   { key: 'ctrl+shift+2', action: 'focus-worm', args: { number: 2 } },

--- a/src/hotkeys/index.ts
+++ b/src/hotkeys/index.ts
@@ -1,3 +1,10 @@
 export { HotkeyManager, type HotkeyHandler } from './manager.js';
+export { KeyboardHookBackend, type KeyEventType, type KeyEventCallback } from './keyboard-hook.js';
 export { loadKeybindings } from './config.js';
-export { parseKeyCombo, type Keybinding, type KeybindingsConfig } from './types.js';
+export {
+  parseKeyCombo,
+  parseKeyComboRaw,
+  type Keybinding,
+  type KeybindingsConfig,
+  type HotkeyEventType,
+} from './types.js';

--- a/src/hotkeys/keyboard-hook.ts
+++ b/src/hotkeys/keyboard-hook.ts
@@ -1,0 +1,120 @@
+import koffi from 'koffi';
+
+// ── Constants ──────────────────────────────────────────────────────────
+const WH_KEYBOARD_LL = 13;
+const WM_KEYDOWN = 0x0100;
+const WM_KEYUP = 0x0101;
+const WM_SYSKEYDOWN = 0x0104;
+const WM_SYSKEYUP = 0x0105;
+const HC_ACTION = 0;
+const PM_REMOVE = 0x0001;
+
+// ── Structs ────────────────────────────────────────────────────────────
+const KBDLLHOOKSTRUCT = koffi.struct('KBDLLHOOKSTRUCT', {
+  vkCode: 'uint32',
+  scanCode: 'uint32',
+  flags: 'uint32',
+  time: 'uint32',
+  dwExtraInfo: 'uintptr',
+});
+
+const POINT = koffi.struct('LLKPOINT', { x: 'long', y: 'long' });
+const MSG = koffi.struct('LLKMSG', {
+  hwnd: 'long',
+  message: 'uint',
+  wParam: 'ulong',
+  lParam: 'long',
+  time: 'uint',
+  pt: POINT,
+});
+
+// ── FFI bindings ───────────────────────────────────────────────────────
+const user32 = koffi.load('user32.dll');
+const kernel32 = koffi.load('kernel32.dll');
+
+const LowLevelKeyboardProc = koffi.proto(
+  'LowLevelKeyboardProc',
+  'intptr',
+  ['int', 'uintptr', 'KBDLLHOOKSTRUCT*'],
+);
+
+const SetWindowsHookExW = user32.func(
+  'pointer SetWindowsHookExW(int idHook, LowLevelKeyboardProc* lpfn, pointer hMod, uint dwThreadId)',
+);
+const UnhookWindowsHookEx = user32.func('bool UnhookWindowsHookEx(pointer hhk)');
+const CallNextHookEx = user32.func(
+  'intptr CallNextHookEx(pointer hhk, int nCode, uintptr wParam, KBDLLHOOKSTRUCT* lParam)',
+);
+const PeekMessageW = user32.func(
+  'bool PeekMessageW(_Out_ LLKMSG* lpMsg, long hWnd, uint wMsgFilterMin, uint wMsgFilterMax, uint wRemoveMsg)',
+);
+const GetModuleHandleW = kernel32.func('pointer GetModuleHandleW(pointer lpModuleName)');
+
+// ── Types ──────────────────────────────────────────────────────────────
+export type KeyEventType = 'down' | 'up';
+export type KeyEventCallback = (vk: number, type: KeyEventType) => boolean;
+
+// ── Class ──────────────────────────────────────────────────────────────
+export class KeyboardHookBackend {
+  private hook: unknown = null;
+  // Store the registered callback to prevent garbage collection
+  private registeredCallback: unknown = null;
+
+  install(callback: KeyEventCallback): void {
+    if (this.hook) {
+      throw new Error('Hook already installed');
+    }
+
+    const hookProc = (
+      nCode: number,
+      wParam: number,
+      lParam: { vkCode: number; scanCode: number; flags: number; time: number; dwExtraInfo: number },
+    ): number => {
+      if (nCode === HC_ACTION) {
+        const vk = lParam.vkCode;
+        let eventType: KeyEventType;
+
+        if (wParam === WM_KEYDOWN || wParam === WM_SYSKEYDOWN) {
+          eventType = 'down';
+        } else if (wParam === WM_KEYUP || wParam === WM_SYSKEYUP) {
+          eventType = 'up';
+        } else {
+          return CallNextHookEx(this.hook, nCode, wParam, lParam) as number;
+        }
+
+        const suppress = callback(vk, eventType);
+        if (suppress) {
+          return 1;
+        }
+      }
+      return CallNextHookEx(this.hook, nCode, wParam, lParam) as number;
+    };
+
+    this.registeredCallback = koffi.register(hookProc, koffi.pointer(LowLevelKeyboardProc));
+    const hMod = GetModuleHandleW(null);
+    this.hook = SetWindowsHookExW(WH_KEYBOARD_LL, this.registeredCallback, hMod, 0);
+
+    if (!this.hook) {
+      this.registeredCallback = null;
+      throw new Error('SetWindowsHookExW failed');
+    }
+  }
+
+  uninstall(): void {
+    if (this.hook) {
+      UnhookWindowsHookEx(this.hook);
+      this.hook = null;
+    }
+    if (this.registeredCallback) {
+      koffi.unregister(this.registeredCallback as Parameters<typeof koffi.unregister>[0]);
+      this.registeredCallback = null;
+    }
+  }
+
+  pumpMessages(): void {
+    const msg = {} as Record<string, unknown>;
+    while (PeekMessageW(msg, 0, 0, 0, PM_REMOVE) as boolean) {
+      // Drain the message queue so the LL hook callback fires
+    }
+  }
+}

--- a/src/hotkeys/manager.ts
+++ b/src/hotkeys/manager.ts
@@ -1,42 +1,69 @@
-import { Win32HotkeyBackend } from './win32-hotkeys.js';
+import { KeyboardHookBackend } from './keyboard-hook.js';
 import { loadKeybindings } from './config.js';
-import { parseKeyCombo, type Keybinding } from './types.js';
+import { parseKeyComboRaw, type Keybinding, type HotkeyEventType } from './types.js';
 
-export type HotkeyHandler = (action: string, args?: Record<string, unknown>) => void;
+export type HotkeyHandler = (
+  action: string,
+  eventType: HotkeyEventType,
+  args?: Record<string, unknown>,
+) => void;
+
+interface ParsedBinding {
+  action: string;
+  mode: 'press' | 'hold';
+  keys: number[]; // non-modifier VK codes
+  modifierKeys: [number, number][]; // pairs of [left, right] VKs per modifier
+  totalKeyCount: number; // keys.length + modifierKeys.length — for specificity sort
+  args?: Record<string, unknown>;
+}
 
 export class HotkeyManager {
-  private backend = new Win32HotkeyBackend();
-  private bindings = new Map<number, Keybinding>(); // id -> binding
+  private backend = new KeyboardHookBackend();
+  private bindings: ParsedBinding[] = [];
   private handler: HotkeyHandler | null = null;
-  private pollInterval: ReturnType<typeof setInterval> | null = null;
-  private nextId = 1;
+  private pumpInterval: ReturnType<typeof setInterval> | null = null;
+
+  // Track currently pressed VK codes
+  private pressedKeys = new Set<number>();
+  // Track which hold-mode actions are currently active
+  private activeHolds = new Map<string, boolean>();
 
   start(): void {
     const config = loadKeybindings();
     if (!config.enabled) return;
 
+    // Parse all bindings
     for (const binding of config.bindings) {
       try {
-        const { modifiers, vk } = parseKeyCombo(binding.key);
-        const id = this.nextId++;
-        if (this.backend.register(id, modifiers, vk)) {
-          this.bindings.set(id, binding);
-        }
+        const { keys, modifierKeys } = parseKeyComboRaw(binding.key);
+        this.bindings.push({
+          action: binding.action,
+          mode: (binding.mode as 'press' | 'hold') ?? 'press',
+          keys,
+          modifierKeys,
+          totalKeyCount: keys.length + modifierKeys.length,
+          args: binding.args as Record<string, unknown> | undefined,
+        });
       } catch (e) {
-        // Skip invalid bindings
-        console.error(`Failed to register hotkey ${binding.key}:`, e);
+        console.error(`Failed to parse hotkey ${binding.key}:`, e);
       }
     }
 
-    // Poll for hotkey messages every 50ms
-    this.pollInterval = setInterval(() => {
-      let hotkeyId: number | null;
-      while ((hotkeyId = this.backend.poll()) !== null) {
-        const binding = this.bindings.get(hotkeyId);
-        if (binding && this.handler) {
-          this.handler(binding.action, binding.args as Record<string, unknown> | undefined);
-        }
+    // Sort by specificity: most keys first (most specific matches win)
+    this.bindings.sort((a, b) => b.totalKeyCount - a.totalKeyCount);
+
+    // Install the low-level keyboard hook
+    this.backend.install((vk, type) => {
+      if (type === 'down') {
+        return this.handleKeyDown(vk);
+      } else {
+        return this.handleKeyUp(vk);
       }
+    });
+
+    // Pump messages every 50ms so the hook callback fires
+    this.pumpInterval = setInterval(() => {
+      this.backend.pumpMessages();
     }, 50);
   }
 
@@ -45,11 +72,65 @@ export class HotkeyManager {
   }
 
   stop(): void {
-    if (this.pollInterval) {
-      clearInterval(this.pollInterval);
-      this.pollInterval = null;
+    if (this.pumpInterval) {
+      clearInterval(this.pumpInterval);
+      this.pumpInterval = null;
     }
-    this.backend.dispose();
-    this.bindings.clear();
+    this.backend.uninstall();
+    this.bindings = [];
+    this.pressedKeys.clear();
+    this.activeHolds.clear();
+  }
+
+  private comboMatches(binding: ParsedBinding): boolean {
+    // All non-modifier keys must be pressed
+    for (const k of binding.keys) {
+      if (!this.pressedKeys.has(k)) return false;
+    }
+    // For each modifier, at least one of [left, right] must be pressed
+    for (const [left, right] of binding.modifierKeys) {
+      if (!this.pressedKeys.has(left) && !this.pressedKeys.has(right)) return false;
+    }
+    return true;
+  }
+
+  private handleKeyDown(vk: number): boolean {
+    this.pressedKeys.add(vk);
+
+    for (const binding of this.bindings) {
+      if (!this.comboMatches(binding)) continue;
+
+      if (binding.mode === 'press') {
+        this.handler?.(binding.action, 'press', binding.args);
+        return true;
+      }
+
+      if (binding.mode === 'hold') {
+        if (!this.activeHolds.get(binding.action)) {
+          this.activeHolds.set(binding.action, true);
+          this.handler?.(binding.action, 'hold-start', binding.args);
+        }
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private handleKeyUp(vk: number): boolean {
+    this.pressedKeys.delete(vk);
+
+    // Check all active holds — if their combo is no longer fully pressed, end them
+    for (const [action, active] of this.activeHolds) {
+      if (!active) continue;
+
+      const binding = this.bindings.find((b) => b.action === action && b.mode === 'hold');
+      if (binding && !this.comboMatches(binding)) {
+        this.activeHolds.set(action, false);
+        this.handler?.(action, 'hold-end', binding.args);
+      }
+    }
+
+    return false;
   }
 }

--- a/src/hotkeys/types.ts
+++ b/src/hotkeys/types.ts
@@ -9,6 +9,7 @@ export const KeybindingSchema = z.object({
   key: z.string(), // e.g., "ctrl+shift+s"
   action: z.string(), // e.g., "toggle-visibility"
   args: z.record(z.string(), z.unknown()).optional(),
+  mode: z.enum(['press', 'hold']).default('press').optional(),
 });
 export type Keybinding = z.infer<typeof KeybindingSchema>;
 
@@ -17,6 +18,8 @@ export const KeybindingsConfigSchema = z.object({
   bindings: z.array(KeybindingSchema),
 });
 export type KeybindingsConfig = z.infer<typeof KeybindingsConfigSchema>;
+
+export type HotkeyEventType = 'press' | 'hold-start' | 'hold-end';
 
 // Win32 modifier constants
 export const MOD_ALT = 0x0001;
@@ -75,6 +78,7 @@ export const VK_MAP: Record<string, number> = {
   enter: 0x0d,
   escape: 0x1b,
   tab: 0x09,
+  '`': 0xc0,
 };
 
 export function parseKeyCombo(key: string): { modifiers: number; vk: number } {
@@ -111,4 +115,44 @@ export function parseKeyCombo(key: string): { modifiers: number; vk: number } {
 
   if (vk === 0) throw new Error(`No key specified in combo: ${key}`);
   return { modifiers: modifiers | MOD_NOREPEAT, vk };
+}
+
+// Modifier name → [left VK, right VK]
+const MODIFIER_VK_PAIRS: Record<string, [number, number]> = {
+  ctrl: [0xa2, 0xa3], // VK_LCONTROL, VK_RCONTROL
+  control: [0xa2, 0xa3],
+  shift: [0xa0, 0xa1], // VK_LSHIFT, VK_RSHIFT
+  alt: [0xa4, 0xa5], // VK_LMENU, VK_RMENU
+  win: [0x5b, 0x5c], // VK_LWIN, VK_RWIN
+  super: [0x5b, 0x5c],
+};
+
+export function parseKeyComboRaw(key: string): {
+  keys: number[];
+  modifierKeys: [number, number][];
+} {
+  const parts = key
+    .toLowerCase()
+    .split('+')
+    .map((p) => p.trim());
+
+  const keys: number[] = [];
+  const modifierKeys: [number, number][] = [];
+
+  for (const part of parts) {
+    const modPair = MODIFIER_VK_PAIRS[part];
+    if (modPair) {
+      modifierKeys.push(modPair);
+    } else {
+      const code = VK_MAP[part];
+      if (code !== undefined) {
+        keys.push(code);
+      } else {
+        throw new Error(`Unknown key: ${part}`);
+      }
+    }
+  }
+
+  if (keys.length === 0) throw new Error(`No non-modifier key specified in combo: ${key}`);
+  return { keys, modifierKeys };
 }


### PR DESCRIPTION
## Summary
- Replaces Win32 `RegisterHotKey` with `SetWindowsHookEx(WH_KEYBOARD_LL)` for key-down AND key-up detection
- New `KeyboardHookBackend` class using koffi FFI — intercepts all keyboard events, supports hold detection
- `HotkeyManager` rewritten to emit `press`, `hold-start`, `hold-end` events with specificity-based combo matching
- `parseKeyComboRaw()` maps key strings to raw VK code arrays with left/right modifier variants
- Default bindings updated: `ctrl+tab` (hold PTT), `ctrl+tab+`` (voice toggle)
- Matched combos are suppressed to prevent OS default behavior (e.g. Ctrl+Tab window switching)

## Changelog
### Added
- `src/hotkeys/keyboard-hook.ts` — WH_KEYBOARD_LL hook backend via koffi
- `HotkeyEventType` type (`press | hold-start | hold-end`)
- `parseKeyComboRaw()` for raw VK code combo parsing
- Backtick (VK_OEM_3) added to VK_MAP
- `mode` field on `KeybindingSchema` (`press | hold`)

### Changed
- `HotkeyManager` now uses `KeyboardHookBackend` instead of `Win32HotkeyBackend`
- `HotkeyHandler` signature: `(action, eventType, args?)` instead of `(action, args?)`
- Default bindings: `ctrl+tab` (hold) and `ctrl+tab+`` replace `ctrl+alt+space`

## Test plan
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] All 98 existing tests pass
- [ ] Manual: hold Ctrl+Tab → hold-start fires, release → hold-end fires
- [ ] Manual: Ctrl+Tab does NOT trigger Windows task switching while Sworm is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)