### PR TITLE
chore: CI workflow + README badges for OSS polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -3,9 +3,13 @@
   <h1>sworm</h1>
   <p><em>spatial agent orchestration</em></p>
   <p>
+    <a href="https://github.com/dannygardner26/Sworm/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/dannygardner26/Sworm/ci.yml?style=flat-square&label=CI" alt="CI"></a>
     <img src="https://img.shields.io/badge/license-MIT-white?style=flat-square" alt="MIT License">
     <img src="https://img.shields.io/badge/platform-Windows%2011-white?style=flat-square" alt="Windows 11">
     <img src="https://img.shields.io/badge/node-%3E%3D20-white?style=flat-square" alt="Node >= 20">
+    <a href="https://github.com/dannygardner26/Sworm/stargazers"><img src="https://img.shields.io/github/stars/dannygardner26/Sworm?style=flat-square" alt="Stars"></a>
+    <a href="https://github.com/dannygardner26/Sworm/issues"><img src="https://img.shields.io/github/issues/dannygardner26/Sworm?style=flat-square" alt="Issues"></a>
+    <img src="https://img.shields.io/github/last-commit/dannygardner26/Sworm?style=flat-square" alt="Last Commit">
   </p>
 </div>
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow (build, lint, test on Node 20 + 22, Windows)
- Add dynamic shields.io badges to README (CI status, stars, issues, last commit)
- Part of a broader effort to make the repo more discoverable and contributor-friendly

## Changelog
### Added
- `.github/workflows/ci.yml` — CI pipeline running on push/PR to master
- README badges: CI status, GitHub stars, open issues, last commit

## Test plan
- [ ] Verify CI workflow runs on this PR
- [ ] Verify README badges render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)