### PR TITLE
chore: set up dev branch contribution flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, dev]
   pull_request:
-    branches: [master]
+    branches: [master, dev]
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Examples: `feat/add-team-invites`, `fix/upload-parsing-bug`
 
 ## Pull Request Process
 
-1. Branch from `master`.
+1. Branch from `dev` (not `master`).
 2. Make your changes in a feature branch.
 3. Run tests and lint before submitting:
    ```bash
@@ -42,7 +42,9 @@ Examples: `feat/add-team-invites`, `fix/upload-parsing-bug`
    npm run lint
    ```
 4. Include a `## Summary` section in your PR description with bullet points describing the changes.
-5. Open a PR against `master` and wait for review.
+5. Open a PR against `dev` and wait for review.
+
+> **Note:** `master` is the release branch. All contributions go into `dev` first and are merged to `master` at release time.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary
- Update CONTRIBUTING.md to direct all contributor PRs to `dev` instead of `master`
- Add `dev` branch to CI workflow triggers so PRs into dev get automated checks
- `dev` is now the default branch; `master` is the release branch

## Changelog
### Changed
- CONTRIBUTING.md PR instructions now target `dev`
- CI workflow triggers on push/PR to both `master` and `dev`

## Test plan
- [ ] Verify CI runs on PRs targeting `dev`
- [ ] Verify CONTRIBUTING.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)